### PR TITLE
Configurable via ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,45 @@
 FROM openjdk:8-alpine
 LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>"
 
-RUN apk update && apk upgrade && apk --update add curl && rm -rf /tmp/* /var/cache/apk/*
+RUN apk update && apk upgrade \
+ && apk --update add curl openssl \
+ && rm -rf /tmp/* /var/cache/apk/*
 
-ENV VERSION 0.11.0
-ENV JAR jmx_prometheus_httpserver-$VERSION-jar-with-dependencies.jar
+ENV DOCKERIZE_VERSION v0.6.1
+RUN set -o pipefail \
+ && curl -Ls https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    | tar xzv -C /usr/local/bin
+
+ENV JMX_EXPORTER_VERSION 0.11.0
+ENV JMX_EXPORTER_PATH=/opt/jmx_exporter
+ENV JMX_EXPORTER_JAR_NAME jmx_prometheus_httpserver-$JMX_EXPORTER_VERSION-jar-with-dependencies.jar
+ENV JMX_EXPORTER_JAR "$JMX_EXPORTER_PATH/$JMX_EXPORTER_JAR_NAME"
+ENV CONFIG_DIR="$JMX_EXPORTER_PATH/config"
+ENV CONFIG_FILE="$CONFIG_DIR/config.yaml"
+ENV CONFIG_TEMPLATE="$CONFIG_DIR/config.yaml.template"
+
+RUN mkdir -p "$JMX_EXPORTER_PATH/config"
 
 RUN curl -L https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 -o usr/local/bin/dumb-init && chmod +x /usr/local/bin/dumb-init
+RUN curl -L https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/$JMX_EXPORTER_VERSION/$JMX_EXPORTER_JAR_NAME -o "$JMX_EXPORTER_JAR"
 
-RUN mkdir -p /opt/jmx_exporter
-RUN curl -L https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_httpserver/$VERSION/$JAR -o /opt/jmx_exporter/$JAR
+COPY config.yaml.template /opt/jmx_exporter/config/
 COPY start.sh /opt/jmx_exporter/
-COPY config.yml /opt/jmx_exporter/
+
+# Application ENV defaults
+ENV SERVICE_PORT=5556
+ENV START_DELAY_SECONDS=0
+ENV JMX_HOST_PORT=localhost:9010
+ENV JMX_USERNAME=""
+ENV JMX_PASSWORD=""
+ENV JMX_SSL=false
+ENV JMX_LOCAL_PORT=5555
+ENV LOWERCASE_OUTPUT_NAME=false
+ENV LOWERCASE_OUTPUT_LABEL_NAMES=false
+ENV JVM_LOCAL_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=$JMX_LOCAL_PORT"
+
+# 5555 - Local JMX
+# 5556 - Prometheus Metrics Server
+EXPOSE 5555 5556
 
 CMD ["usr/local/bin/dumb-init", "/opt/jmx_exporter/start.sh"]

--- a/README.md
+++ b/README.md
@@ -43,9 +43,18 @@ The configuration options are documented: [https://github.com/prometheus/jmx_exp
 
 Additionally, the following environment variables can be defined
 
--	SERVICE_PORT - what port to run the service (if you don't like 5556)
--	JVM_OPTS - any additional options, Xmx etc.
--	CONFIG_YML - override the location of config.yaml (default: /opt/jmx_exporter/config.yml which monitors jmx exporter's jvm)
+Name     | Description
+---------|------------
+`SERVICE_PORT` | Port to run the JMX exporter. Prometheus will scrape `/metrics` on this port. Default: 5556
+`JMX_LOCAL_OPTIONS` | The JVM options for the prometheus exporter process.
+`START_DELAY_SECONDS` | Start delay before serving requests. Any requests within the delay period will result in an empty metrics set. Default: 0
+`JMX_HOST_PORT` | The host and port to connect to via remote JMX. If neither this nor `JMX_URL` is specified, will talk to the local JVM.
+`JMX_USERNAME` | The username to be used in remote JMX password authentication.
+`JMX_PASSWORD` | The password to be used in remote JMX password authentication.
+`JMX_SSL`      | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
+`LOWERCASE_OUTPUT_NAME` | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
+`LOWERCASE_OUTPUT_LABEL_NAMES` | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
+
 
 Using with Prometheus
 ---------------------

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -1,0 +1,12 @@
+---
+startDelaySeconds: {{ .Env.START_DELAY_SECONDS }}
+hostPort: {{ .Env.JMX_HOST_PORT }}
+username: {{ .Env.JMX_USERNAME }}
+password: {{ .Env.JMX_PASSWORD }}
+ssl: {{ .Env.JMX_SSL }}
+lowercaseOutputName: {{ .Env.LOWERCASE_OUTPUT_NAME }}
+lowercaseOutputLabelNames: {{ .Env.LOWERCASE_OUTPUT_LABEL_NAMES }}
+#whitelistObjectNames:
+#blacklistObjectNames:
+rules:
+  - pattern: ".*"

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,0 @@
----
-hostPort: localhost:5555
-username:
-password:
-
-rules:
-- pattern: ".*"

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-CONFIG_DIR="$JMX_EXPORTER_PATH/config"
-CONFIG_FILE="$CONFIG_DIR/config.yaml"
-CONFIG_TEMPLATE="$CONFIG_DIR/config.yaml.template"
-
 # Main JAR
 test -f "$JMX_EXPORTER_JAR" || { echo "INTERNAL DOCKER ERROR: JMX exporter jar file not found: $JMX_EXPORTER_JAR - This indicates a problem with the Docker build."; exit 1; }
 

--- a/start.sh
+++ b/start.sh
@@ -1,15 +1,34 @@
 #!/bin/sh
 
-if [ -z "$SERVICE_PORT" ]; then
-  SERVICE_PORT=5556
-fi
+CONFIG_DIR="$JMX_EXPORTER_PATH/config"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+CONFIG_TEMPLATE="$CONFIG_DIR/config.yaml.template"
 
-if [ -z "$JVM_OPTS" ]; then
-  JVM_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5555"
-fi
+# Main JAR
+test -f "$JMX_EXPORTER_JAR" || { echo "INTERNAL DOCKER ERROR: JMX exporter jar file not found: $JMX_EXPORTER_JAR - This indicates a problem with the Docker build."; exit 1; }
 
-if [ -z "$CONFIG_YML" ]; then
-  CONFIG_YML=/opt/jmx_exporter/config.yml
-fi
+# Debug block...
+  echo "DEBUG: Docker image configuration."
+  echo "JMX_EXPORTER_VERSION: $JMX_EXPORTER_VERSION"
+  echo "JMX_EXPORTER_JAR: $JMX_EXPORTER_JAR"
+  echo ""
+  echo "DEBUG: Runtime environment variables set/received..."
+  echo "JMX_EXPORTER_VERSION: $JMX_EXPORTER_VERSION"
+  echo "SERVICE_PORT: $SERVICE_PORT"
+  echo "START_DELAY_SECONDS: $START_DELAY_SECONDS"
+  echo "JMX_HOST_PORT: $JMX_HOST_PORT"
+  echo "JMX_USERNAME: $JMX_USERNAME"
+  echo "JMX_PASSWORD: $JMX_PASSWORD"
+  echo "JMX_SSL: $JMX_SSL"
+  echo "LOWERCASE_OUTPUT_NAME: $LOWERCASE_OUTPUT_NAME"
+  echo "LOWERCASE_OUTPUT_LABEL_NAMES: $LOWERCASE_OUTPUT_LABEL_NAMES"
+  echo "WHITELIST_OBJECT_NAMES: $WHITELIST_OBJECT_NAMES"
+  echo "BLACKLIST_OBJECT_NAMES: $BLACKLIST_OBJECT_NAMES"
+  echo "JVM_LOCAL_OPTS: $JVM_LOCAL_OPTS"
+  echo
 
-java $JVM_OPTS -jar /opt/jmx_exporter/jmx_prometheus_httpserver-$VERSION-jar-with-dependencies.jar $SERVICE_PORT $CONFIG_YML
+# Service launch
+echo "Starting Service..."
+echo java $JVM_LOCAL_OPTS -jar $JMX_EXPORTER_JAR $SERVICE_PORT $CONFIG_FILE
+dockerize -template "$CONFIG_TEMPLATE:$CONFIG_FILE" \
+  java $JVM_LOCAL_OPTS -jar $JMX_EXPORTER_JAR $SERVICE_PORT $CONFIG_FILE


### PR DESCRIPTION
Adds the Dockerize tool and a configuration template so that the JMX exporter can be configured at runtime. The blacklist, whitelist, and rules options are not currently configurable because they're multi-value.